### PR TITLE
Fixing a tab error in MultiFASTA

### DIFF
--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -129,6 +129,7 @@ class MultiFASTA(object):
         fh.close()
 
         # we split according to ">2 character
+        print len(data.split(">")
         for thisfasta in data.split(">")[1:]:
             print thisfasta
             f = FASTA()

--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -129,8 +129,8 @@ class MultiFASTA(object):
         fh.close()
 
         # we split according to ">2 character
-        print len(data.split(">"))
-        for thisfasta in data.split(">")[1:]:
+        print len(data.split(">")[1:])
+        for thisfasta in data.split(">"):
             print thisfasta
             f = FASTA()
             f._fasta = f._interpret(thisfasta)

--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -132,8 +132,6 @@ class MultiFASTA(object):
         for thisfasta in data.split(">")[1:]:
             f = FASTA()
             f._fasta = f._interpret(thisfasta)
-            print f._fasta
-            print f.accession
             try: dummy = f.accession, self.ids # just to try
             except:pass
             if f.accession is not None and f.accession not in self.ids:

--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -130,6 +130,7 @@ class MultiFASTA(object):
 
         # we split according to ">2 character
         for thisfasta in data.split(">")[1:]:
+            print thisfasta
             f = FASTA()
             f._fasta = f._interpret(thisfasta)
             try: dummy = f.accession, self.ids # just to try

--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -129,7 +129,7 @@ class MultiFASTA(object):
         fh.close()
 
         # we split according to ">2 character
-        print len(data.split(">")
+        print len(data.split(">"))
         for thisfasta in data.split(">")[1:]:
             print thisfasta
             f = FASTA()

--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -141,7 +141,7 @@ class MultiFASTA(object):
             else:
                 if self.verbose:
                     print("Accession %s is already in the ids list or could not be interpreted. skipped" % str(f.accession))
-            return
+        return
 
     def _get_df(self):
         df =  pd.concat([self.fasta[id_].df for id_ in self.fasta.keys()])

--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -129,11 +129,10 @@ class MultiFASTA(object):
         fh.close()
 
         # we split according to ">2 character
-        print len(data.split(">")[1:])
-        for thisfasta in data.split(">"):
-            print thisfasta
+        for thisfasta in data.split(">")[1:]:
             f = FASTA()
             f._fasta = f._interpret(thisfasta)
+            print f._fasta
             try: dummy = f.accession, self.ids # just to try
             except:pass
             if f.accession is not None and f.accession not in self.ids:
@@ -427,6 +426,7 @@ class FASTA(object):
         if data.count(">sp|")>1:
             raise ValueError("""It looks like your FASTA file contains more than
             one FASTA. You must use MultiFASTA class instead""")
+
         self._fasta = data[:]
         self._fasta = self._fasta[0]
         if self.dbtype not in self.known_dbtypes:

--- a/biokit/io/fasta.py
+++ b/biokit/io/fasta.py
@@ -133,6 +133,7 @@ class MultiFASTA(object):
             f = FASTA()
             f._fasta = f._interpret(thisfasta)
             print f._fasta
+            print f.accession
             try: dummy = f.accession, self.ids # just to try
             except:pass
             if f.accession is not None and f.accession not in self.ids:


### PR DESCRIPTION
Previous function would return after reading one entry. Trivial fix allows for intended use